### PR TITLE
フッターにサイトマップ及びコピーライトを追加

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -2,10 +2,19 @@ import styles from './Footer.module.css'
 
 export default function Footer() {
   return (
-    <>
-      <footer className={styles.footer}>
-        <img src="/logo-netlify.svg" alt="Netlify Logo" className={styles.logo} />
-      </footer>
-    </>
+    <footer className={styles.footer}>
+      <div className={styles.sitemap}>
+        <div className={styles.sitemapSection}>
+          <ul>
+            <li><a href="/about">about</a></li>
+            <li><a href="/services">services</a></li>
+            <li><a href="/contact">contact</a></li>
+          </ul>
+        </div>
+      </div>
+      <div>
+        <p>&copy; 2024 LiNKCREW Inc.</p>
+      </div>
+    </footer>
   )
 }

--- a/components/Footer.module.css
+++ b/components/Footer.module.css
@@ -1,13 +1,41 @@
 .footer {
+  /* position: fixed; */
+  bottom: 0;
   width: 100%;
-  height: 100px;
   border-top: 1px solid #eaeaea;
   display: flex;
+  flex-direction: column;
   justify-content: center;
   align-items: center;
+  padding: 10px 0;
+  height: auto;
 }
 
 .logo {
   height: 3em;
   margin: 5px;
+}
+
+.sitemap {
+  display: flex;
+  justify-content: center;
+  padding-bottom: 20px;
+}
+
+.sitemapSection {
+  margin: 0 20px;
+}
+
+.sitemapSection h4 {
+  margin-bottom: 10px;
+}
+
+.sitemapSection ul {
+  list-style: none;
+  padding: 0;
+}
+
+.sitemapSection ul li a {
+  color: black;
+  text-decoration: none;
 }


### PR DESCRIPTION
フッターにサイトマップとコピーライトを追加しました。

<img width="1512" alt="スクリーンショット 2024-01-05 0 42 57" src="https://github.com/linkcrew/next-netlify-starter/assets/90540265/472867de-5714-448c-9471-ad25e62fa78a">