### PR TITLE
キャリア支援の遷移タイトル統一

### DIFF
--- a/components/ServiceComponent.js
+++ b/components/ServiceComponent.js
@@ -16,7 +16,7 @@ export default function ServiceComponent() {
     },
     {
       title: careerSupport,
-      link: "#支援",
+      link: "#キャリア支援",
     },
   ];
 


### PR DESCRIPTION
サービス一覧のコンポーネントからサービス詳細へ遷移させるために遷移時のタイトルを統一します。